### PR TITLE
Add color extensions for hex and 255

### DIFF
--- a/Sources/CubeFoundationSwiftUI/Color/Color+255.swift
+++ b/Sources/CubeFoundationSwiftUI/Color/Color+255.swift
@@ -1,0 +1,54 @@
+//
+//  Color+255.swift
+//  CubeFoundation
+//
+//  Created by Ben Shutt on 13/02/2023.
+//  Copyright © 2023 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+public extension Color {
+
+    /// Shorthand for creating a `UIColor` with RGBA ranges in [0, 255].
+    ///
+    /// - Parameters:
+    ///   - colorSpace: Color space, defaults to `.sRGB`
+    ///   - red: Red component in [0, 255]
+    ///   - green: Green component in [0, 255]
+    ///   - blue: Blue component in [0, 255]
+    ///   - opacity: Opacity component in [0, 255], defaults to 255
+    init(
+        _ colorSpace: RGBColorSpace = .sRGB,
+        red255 red: Double,
+        green: Double,
+        blue: Double,
+        opacity: Double = 255
+    ) {
+        self.init(
+            colorSpace,
+            red: red / 255,
+            green: green / 255,
+            blue: blue / 255,
+            opacity: opacity / 255
+        )
+    }
+
+    /// Shorthand for creating a `UIColor` with white in [0, 255].
+    ///
+    /// - Parameters:
+    ///   - colorSpace: Color space, defaults to `.sRGB`
+    ///   - white: White component in [0, 255]
+    ///   - opacity: Opacity component in [0, 255]
+    init(
+        _ colorSpace: RGBColorSpace = .sRGB,
+        white255 white: Double,
+        opacity: Double = 255
+    ) {
+        self.init(
+            colorSpace,
+            white: white / 255,
+            opacity: opacity / 255
+        )
+    }
+}

--- a/Sources/CubeFoundationSwiftUI/Color/Color+Hex.swift
+++ b/Sources/CubeFoundationSwiftUI/Color/Color+Hex.swift
@@ -1,0 +1,105 @@
+//
+//  Color+Hex.swift
+//  CubeFoundation
+//
+//  Created by Ben Shutt on 13/02/2023.
+//  Copyright © 2023 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+public extension Color {
+
+    /// RGBA hex `String`
+    typealias RGBAHex = String
+
+    /// Initialize `UIColor` with the given HEX `string`.
+    ///
+    /// The `string` can be of the form:
+    /// - RGB (12-bit)
+    /// - RGB (24-bit)
+    /// - RGBA (32-bit)
+    ///
+    /// - Parameter string: `RGBAHex` hex formatted color
+    init?(hexString string: RGBAHex) {
+        // Trim non-alphanumerics (which includes the # character)
+        let hex = string.trimmingCharacters(in: .hexadecimal.inverted)
+
+        var int = UInt64()
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (r, g, b, a) = (
+                (int >> 8) * 17, // r
+                (int >> 4 & 0xF) * 17, // g
+                (int & 0xF) * 17, // b
+                255 // a
+            )
+        case 6: // RGB (24-bit)
+            (r, g, b, a) = (
+                int >> 16, // r
+                int >> 8 & 0xFF, // g
+                int & 0xFF, // b
+                255 // a
+            )
+        case 8: // RGBA (32-bit)
+            (r, g, b, a) = (
+                int >> 24, // r
+                int >> 16 & 0xFF, // g
+                int >> 8 & 0xFF, // b
+                int & 0xFF // a
+            )
+        default:
+            return nil
+        }
+
+        self.init(
+            red255: Double(r),
+            green: Double(g),
+            blue: Double(b),
+            opacity: Double(a)
+        )
+    }
+
+
+    /// `UIColor` to RGB HEX `String`
+    ///
+    /// - Parameter opacity: Include the opacity component
+    func hexString(opacity: Bool = true) -> String {
+        let rgba = self.rgba
+
+        var hex = String(
+            format: "#%02X%02X%02X",
+            rgba.red.int255,
+            rgba.green.int255,
+            rgba.blue.int255
+        )
+
+        if opacity {
+            hex += String(format: "%02X", rgba.opacity.int255)
+        }
+
+        return hex
+    }
+}
+
+// MARK: - Double + Color
+
+private extension Double {
+
+    /// Convert to integer 255 color component
+    var int255: Int {
+        Int((self * 255).rounded())
+    }
+}
+
+// MARK: - CharacterSet + Color
+
+private extension CharacterSet {
+
+    /// Hexadecimal characters (uppercase and lowercase)
+    static var hexadecimal: CharacterSet {
+        CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+    }
+}

--- a/Sources/CubeFoundationSwiftUI/Color/Color+RGBA.swift
+++ b/Sources/CubeFoundationSwiftUI/Color/Color+RGBA.swift
@@ -1,0 +1,58 @@
+//
+//  Color+RGBA.swift
+//  CubeFoundation
+//
+//  Created by Ben Shutt on 13/02/2023.
+//  Copyright © 2023 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+typealias AppColor = UIColor
+#elseif canImport(AppKit)
+import AppKit
+typealias AppColor = NSColor
+#endif
+
+extension Color {
+
+    /// Red, green, blue opacity components of a color.
+    /// Components in the range [0, 1]
+    struct RGBA {
+
+        /// Red component
+        var red: Double
+
+        /// Green component
+        var green: Double
+
+        /// Blue component
+        var blue: Double
+
+        /// Opacity component
+        var opacity: Double
+    }
+
+    /// Get `RGBA` components from `AppColor`
+    ///
+    /// - Note:
+    /// There doesn't seem to be a SwiftUI way of extracting the RGBA components as of yet.
+    var rgba: RGBA {
+        let appColor = AppColor(self)
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var opacity: CGFloat = 0
+        appColor.getRed(&red, green: &green, blue: &blue, alpha: &opacity)
+
+        return RGBA(
+            red: Double(red),
+            green: Double(green),
+            blue: Double(blue),
+            opacity: Double(opacity)
+        )
+    }
+}


### PR DESCRIPTION
- Color+255 to make colors with 255 shorthand
- Color+Hex to map to and from hex colors like `#12ABEF`
- Color+RGBA, internal extension, maps `UIColor` and `AppColor` to and from the RGBA components