### PR TITLE
🟢 Low: Add Support For System Font [Medium]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "CubeFoundation",
     platforms: [
-        .iOS(.v15), .macOS(.v10_15),
+        .iOS(.v15),
+        .macOS(.v10_15)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "CubeFoundation",
             targets: ["CubeFoundation"]
@@ -17,15 +17,9 @@ let package = Package(
         .library(
             name: "CubeFoundationSwiftUI",
             targets: ["CubeFoundationSwiftUI"]
-        ),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        )
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "CubeFoundation",
             dependencies: []
@@ -33,6 +27,6 @@ let package = Package(
         .target(
             name: "CubeFoundationSwiftUI",
             dependencies: []
-        ),
+        )
     ]
 )

--- a/Sources/CubeFoundationSwiftUI/Color/Color+Hex.swift
+++ b/Sources/CubeFoundationSwiftUI/Color/Color+Hex.swift
@@ -62,7 +62,6 @@ public extension Color {
         )
     }
 
-
     /// `Color` to RGB hex `String`
     ///
     /// - Parameter opacity: Include the opacity component

--- a/Sources/CubeFoundationSwiftUI/Text/CustomFont.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/CustomFont.swift
@@ -15,11 +15,11 @@ public enum CustomFont: ExpressibleByStringLiteral, Equatable, Hashable {
     case system
 
     /// Custom font with name
-    case custom(String)
+    case custom(Font.Name)
 
     /// Initialize with string literal making a custom font with name
     /// - Parameter value: `String`
     public init(stringLiteral value: String) {
-        self = .custom(value)
+        self = .custom(.init(stringLiteral: value))
     }
 }

--- a/Sources/CubeFoundationSwiftUI/Text/CustomFont.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/CustomFont.swift
@@ -1,0 +1,25 @@
+//
+//  CustomFont.swift
+//  CubeFoundation
+//
+//  Created by Ben Shutt on 19/05/2023.
+//  Copyright © 2023 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+/// Types of font
+public enum CustomFont: ExpressibleByStringLiteral, Equatable, Hashable {
+
+    /// System font
+    case system
+
+    /// Custom font with name
+    case custom(String)
+
+    /// Initialize with string literal making a custom font with name
+    /// - Parameter value: `String`
+    public init(stringLiteral value: String) {
+        self = .custom(value)
+    }
+}

--- a/Sources/CubeFoundationSwiftUI/Text/FontWeight+Extensions.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/FontWeight+Extensions.swift
@@ -77,7 +77,7 @@ extension Font.Weight: ExpressibleByIntegerLiteral {
         case .medium:
             return .medium
         case .regular:
-            return .medium
+            return .regular
         case .light:
             return .light
         case .thin:

--- a/Sources/CubeFoundationSwiftUI/Text/FontWeight+Extensions.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/FontWeight+Extensions.swift
@@ -62,4 +62,30 @@ extension Font.Weight: ExpressibleByIntegerLiteral {
             return "Unknown"
         }
     }
+
+    /// Map to `UIFont.Weight` equivalent
+    public var uiWeight: UIFont.Weight {
+        switch self {
+        case .black:
+            return .black
+        case .heavy:
+            return .heavy
+        case .bold:
+            return .bold
+        case .semibold:
+            return .semibold
+        case .medium:
+            return .medium
+        case .regular:
+            return .medium
+        case .light:
+            return .light
+        case .thin:
+            return .thin
+        case .ultraLight:
+            return .ultraLight
+        default:
+            return .regular
+        }
+    }
 }

--- a/Sources/CubeFoundationSwiftUI/Text/TextStyle.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/TextStyle.swift
@@ -41,7 +41,7 @@ public struct TextStyle: Hashable {
         case .system:
             return .system(size: size)
         case let .custom(name):
-            return .custom(name, size: size)
+            return .custom(name.string, size: size)
         }
     }
 

--- a/Sources/CubeFoundationSwiftUI/Text/TextStyle.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/TextStyle.swift
@@ -9,7 +9,8 @@
 import SwiftUI
 
 public struct TextStyle: Hashable {
-    public var font: Font.Name
+
+    public var font: CustomFont
     public var weight: Font.Weight
     public var size: CGFloat
     public var lineHeight: CGFloat
@@ -17,7 +18,7 @@ public struct TextStyle: Hashable {
     public var underline = false
 
     public init(
-        font: Font.Name,
+        font: CustomFont,
         weight: Font.Weight,
         size: CGFloat,
         lineHeight: CGFloat,
@@ -30,5 +31,27 @@ public struct TextStyle: Hashable {
         self.lineHeight = lineHeight
         self.letter = letter
         self.underline = underline
+    }
+
+    // MARK: - Helper
+
+    /// Make a `Font`
+    public var mappedFont: Font {
+        switch font {
+        case .system:
+            return .system(size: size)
+        case let .custom(name):
+            return .custom(name, size: size)
+        }
+    }
+
+    /// Make a `UIFont`
+    public var uiFont: UIFont? {
+        switch font {
+        case .system:
+            return UIFont.systemFont(ofSize: size, weight: weight.uiWeight)
+        case let .custom(name):
+            return UIFont(name: "\(name) \(weight.name)", size: size)
+        }
     }
 }

--- a/Sources/CubeFoundationSwiftUI/Text/View+TextStyle.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/View+TextStyle.swift
@@ -13,12 +13,11 @@ public extension Text {
     @available(iOS, obsoleted: 16.0, message: "Use `View.style(_ style: TextStyle)`")
     func style(_ style: TextStyle) -> some View {
         // Initialise as a UIFont to get the intrinsic line height.
-        let uiFont = UIFont(name: "\(style.font.string) \(style.weight.name)", size: style.size)
-        let fontLineHeight = uiFont?.lineHeight ?? style.size
+        let fontLineHeight = style.uiFont?.lineHeight ?? style.size
         let lineSpacing = style.lineHeight - fontLineHeight
 
         return self
-            .font(.custom(style.font.string, size: style.size).weight(style.weight))
+            .font(style.mappedFont.weight(style.weight))
             .tracking(style.letter)
             .underline(style.underline)
             .lineSpacing(lineSpacing)
@@ -32,12 +31,11 @@ public extension View {
     @available(iOS 16.0, *)
     func style(_ style: TextStyle) -> some View {
         // Initialise as a UIFont to get the intrinsic line height.
-        let uiFont = UIFont(name: "\(style.font.string) \(style.weight.name)", size: style.size)
-        let fontLineHeight = uiFont?.lineHeight ?? style.size
+        let fontLineHeight = style.uiFont?.lineHeight ?? style.size
         let lineSpacing = style.lineHeight - fontLineHeight
 
         return self
-            .font(.custom(style.font.string, size: style.size).weight(style.weight))
+            .font(style.mappedFont.weight(style.weight))
             .tracking(style.letter)
             .underline(style.underline)
             .lineSpacing(lineSpacing)


### PR DESCRIPTION
# TL;DR
New feature to add support for system fonts.

# Summary
Previously, a `TextStyle` had to be constructed with:
```swift
 TextStyle(font: "Some String", ... )
```
now I have created a `CustomFont` `enum` which takes:
```swift
case .system
case .custom(String) // Name of the custom font
```
and updated the `TextStyle`

# Notes

1) I'm not attached to any of the names, please do suggest improvements
2) It is backwards compatible atm, but wondering if this might work nice to construct `TextStyle`s like:
```swift
TextStyle(.system, ...) // or
TextStyle("OpenSans", ...)
```

it would free up the property named `font` which I'm having to work around atm to use `mappedFont` (See files).