### PR TITLE
Update font getter for SwiftUI

### DIFF
--- a/Sources/CubeFoundationSwiftUI/Text/TextStyle.swift
+++ b/Sources/CubeFoundationSwiftUI/Text/TextStyle.swift
@@ -57,7 +57,7 @@ public struct TextStyle: Hashable {
     public var font: Font {
         switch fontName {
         case .system:
-            return .system(size: scaledSize)
+            return .system(size: scaledSize, weight: weight)
         case let .custom(name):
             return .custom(name, size: scaledSize)
         }


### PR DESCRIPTION
### Brief
When using the font getter with attributed strings in SwiftUI, the weight wasn't being utilised. 

This is needed to match the designs on ARC Childcare, where there is text that displays a higher weight font, part way through the sentence.

<img width="352" alt="Screenshot 2024-11-25 at 08 20 10" src="https://github.com/user-attachments/assets/31e658b9-e416-4f48-908f-5e28284c3f19">
